### PR TITLE
Add treatments to Nightscout data pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A tool for pulling Nightscout data into InfluxDB.
 Copy [`example.env`](./example.env) to `.env`. Make sure to fill in the required
 values.
 
-By default, running `ns-to-influxdb` will attempt to transfer all entries from
+By default, running `ns-to-influxdb` will attempt to transfer all entries and treatments from
 your Nightscout site to the target InfluxDB. If you want to use a custom
 timeframe, use the `--from` and `--to` flags:
 
@@ -28,13 +28,13 @@ ns-to-influxdb [--from 2024-10-01] [--to 2024-11-01]
 
 ### Crontab
 
-To periodically pull your latest Nightscout entries into InfluxDB, simply run
+To periodically pull your latest Nightscout entries and treatments into InfluxDB, simply run
 this tool as a cron job.
 
 ## Roadmap
 
 - [x] Entries (just sensor values)
-- [ ] Treatments (boluses, carbs, etc...)
+- [x] Treatments (boluses, carbs, etc...)
 
 ## Work in progress
 

--- a/example.env
+++ b/example.env
@@ -1,4 +1,3 @@
-
 # InfluxDB configuration
 INFLUXDB_URL=http://localhost:8086
 # # This token should have read & write access


### PR DESCRIPTION
Add functionality to pull 'treatments' from Nightscout in addition to 'entries'.

* **src/ns-to-influxdb.ts**
  - Add `fetchNightscoutTreatments` function to fetch treatments from Nightscout.
  - Modify `main` function to call `fetchNightscoutTreatments` and write treatments to InfluxDB.
  - Update `writeEntriesToInflux` function to handle treatments.
  - Refer to both records as `NightscoutRecords` in the main function.
  - Add a TODO comment to look into other possible types of treatments.
  - Refactor `NightscoutTreatment` type to use discriminators for different possible eventTypes.

* **example.env**
  - Update comment to mention that the Nightscout token should have read access to 'entries' and 'treatments'.

* **README.md**
  - Update documentation to indicate that both 'entries' and 'treatments' are being transferred from Nightscout to InfluxDB.
  - Mark treatments as completed in the roadmap.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nielsmaerten/nightscout-influxdb/pull/2?shareId=8c5b4bdc-e139-461a-b4ad-637110e4a2b3).